### PR TITLE
Ignore dead processes

### DIFF
--- a/wtrd.c
+++ b/wtrd.c
@@ -4,6 +4,7 @@
 #include <sys/user.h>
 
 #include <err.h>
+#include <libproc.h>
 #include <libprocstat.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -72,6 +73,9 @@ each_user_process(void callback(struct procstat *prstat, struct kinfo_proc *proc
 	}
 
 	for (uint i = 0; i < nproc; i++) {
+		if (procs[i].ki_stat == PS_DEAD)
+			continue;
+
 		callback(prstat, &procs[i], callback2);
 	}
 


### PR DESCRIPTION
When listing processes, zombies are also listed, but since the process
is dead, it has no more open files and no working directory.

Ensure process information is not the one of a zombie and proceed,
otherwise ignore the entry.

This avoid libprocstat form outputting warnings to stderr.

Fixes #1
