### PR TITLE
Load projects from a configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .depend*
+*.o
+wtrd
+wtrd.debug
+wtrd.full

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
 PROG=	wtrd
+SRCS=	config.c wtrd.c
 CFLAGS=	-Wall -Werror
 LDADD=	-lprocstat
+
+GLIB_FLAGS!=	pkg-config --cflags glib-2.0
+GLIB_LDADD!=	pkg-config --libs glib-2.0
+
+CFLAGS+=	${GLIB_FLAGS}
+LDADD+=		${GLIB_LDADD}
 
 MK_MAN=	no
 

--- a/config.c
+++ b/config.c
@@ -1,0 +1,73 @@
+#include <err.h>
+#include <stdio.h>
+
+#include <glib.h>
+
+#include "config.h"
+
+gsize nroots;
+struct root *roots;
+
+int
+config_load(void)
+{
+	g_auto (GPathBuf) path;
+
+	g_path_buf_init (&path);
+
+	g_path_buf_push(&path, g_get_user_config_dir());
+	g_path_buf_push(&path, "wtr");
+
+	g_autofree char *conf_dir_path = g_path_buf_to_path (&path);
+
+	if (g_mkdir_with_parents(conf_dir_path, 0700) < 0) {
+		warn("Could not create %s", conf_dir_path);
+		return -1;
+	}
+
+	g_path_buf_push(&path, "roots.conf");
+
+	g_autofree char *conf_file_path = g_path_buf_to_path (&path);
+
+	GKeyFile *conf_file = g_key_file_new();
+	if (!g_key_file_load_from_file(conf_file, conf_file_path, G_KEY_FILE_NONE, NULL)) {
+		warn("Could not load configuration from %s", conf_file_path);
+		// TODO: Create a sample configuration with comments to guide the user
+		return -1;
+	}
+	
+	gchar **groups = g_key_file_get_groups(conf_file, &nroots);
+
+	if (nroots == 0) {
+		warnx("Configuration file %s has no projects", conf_file_path);
+		return -1;
+	}
+
+	roots = malloc(sizeof(*roots) * nroots);
+
+	for (int i = 0; i < nroots; i++) {
+		gchar *root;
+		if (!(root = g_key_file_get_string(conf_file, groups[i], "root", NULL))) {
+			warnx("Project %s has no root", groups[i]);
+			return -1;
+		}
+
+		roots[i].root = root;
+		roots[i].active = 0;
+	}
+
+	g_strfreev(groups);
+
+	g_key_file_free(conf_file);
+
+	return 0;
+}
+
+void
+config_free(void)
+{
+	for (int i = 0; i < nroots; i++) {
+		free(roots[i].root);
+	}
+	free(roots);
+}

--- a/config.c
+++ b/config.c
@@ -52,6 +52,7 @@ config_load(void)
 			return -1;
 		}
 
+		roots[i].name = g_strdup(groups[i]);
 		roots[i].root = root;
 		roots[i].active = 0;
 	}
@@ -67,6 +68,7 @@ void
 config_free(void)
 {
 	for (int i = 0; i < nroots; i++) {
+		free(roots[i].name);
 		free(roots[i].root);
 	}
 	free(roots);

--- a/config.h
+++ b/config.h
@@ -1,0 +1,17 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#include <glib.h>
+
+int		 config_load(void);
+void		 config_free(void);
+
+extern gsize nroots;
+struct root {
+	char *root;
+	int active;
+};
+
+extern struct root *roots;
+
+#endif

--- a/config.h
+++ b/config.h
@@ -8,6 +8,7 @@ void		 config_free(void);
 
 extern gsize nroots;
 struct root {
+	char *name;
 	char *root;
 	int active;
 };

--- a/wtrd.c
+++ b/wtrd.c
@@ -11,22 +11,12 @@
 #include <string.h>
 #include <unistd.h>
 
-struct {
-	const char *root;
-	unsigned int active;
-} roots[] = {
-	{ "/usr/home/romain/Projects/FreeBSD",    0 },
-	{ "/usr/home/romain/Projects/choria-io",  0 },
-	{ "/usr/home/romain/Projects/puppetlabs", 0 },
-	{ "/usr/home/romain/Projects/riemann",    0 },
-	{ "/usr/home/romain/Projects/voxpupuli",  0 },
-	{ "/usr/home/romain/Projects/wtr",        0 },
-};
+#include "config.h"
 
 void
 process_working_directory(const char *working_directory)
 {
-	for (unsigned int i = 0; i < sizeof(roots) / sizeof(*roots); i++) {
+	for (int i = 0; i < nroots; i++) {
 		if (strnstr(working_directory, roots[i].root, strlen(roots[i].root)) == working_directory &&
 		    (working_directory[strlen(roots[i].root)] == '/' ||
 		     working_directory[strlen(roots[i].root)] == '\0')) {
@@ -88,7 +78,7 @@ void
 print_wd(void)
 {
 	printf("----\n");
-	for (unsigned int i = 0; i < sizeof(roots) / sizeof(*roots); i++) {
+	for (int i = 0; i < nroots; i++) {
 		if (roots[i].active) {
 			printf("%s\n", roots[i].root);
 		}
@@ -98,7 +88,7 @@ print_wd(void)
 void
 reset_wd(void)
 {
-	for (unsigned int i = 0; i < sizeof(roots) / sizeof(*roots); i++) {
+	for (int i = 0; i < nroots; i++) {
 		roots[i].active = 0;
 	}
 }
@@ -106,12 +96,18 @@ reset_wd(void)
 int
 main(void)
 {
+	if (config_load() < 0) {
+		exit(1);
+	}
+
 	for (;;) {
 		reset_wd();
 		each_user_process(each_process_working_directory, process_working_directory);
 		print_wd();
 		sleep(1);
 	}
+
+	config_free();
 
 	exit(EXIT_SUCCESS);
 }

--- a/wtrd.c
+++ b/wtrd.c
@@ -80,7 +80,7 @@ print_wd(void)
 	printf("----\n");
 	for (int i = 0; i < nroots; i++) {
 		if (roots[i].active) {
-			printf("%s\n", roots[i].root);
+			printf("%s\n", roots[i].name);
 		}
 	}
 }


### PR DESCRIPTION
This PR allow to load user-defined configuration by relying on GLib features to handle XDG directories and key/value configuration files.  Since we are now using GLib, we also switch to a GMainLoop for managing events.

- Load the project root from a configuration file
- Identify projects by name rather than root
- Run the code from a GLib main loop

Fixes #3
