### PR TITLE
Mark active projects in reports

### DIFF
--- a/libwtr/CMakeLists.txt
+++ b/libwtr/CMakeLists.txt
@@ -1,4 +1,16 @@
-add_library(libwtr config.c database.c utils.c)
+add_library(libwtr config.c database.c libwtr.c utils.c)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(deps REQUIRED IMPORTED_TARGET glib-2.0 sqlite3)
 target_link_libraries(libwtr PkgConfig::deps)
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+target_sources(libwtr PUBLIC freebsd.c)
+find_library(libwtr procstat)
+target_link_libraries(libwtr procstat)
+endif (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+target_sources(libwtr PUBLIC linux.c)
+pkg_check_modules(libbsd REQUIRED IMPORTED_TARGET libbsd-overlay)
+target_link_libraries(libwtr PkgConfig::libbsd)
+endif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/libwtr/config.c
+++ b/libwtr/config.c
@@ -6,7 +6,7 @@
 #include "config.h"
 #include "database.h"
 
-gsize nroots;
+size_t nroots;
 struct root *roots;
 
 int

--- a/libwtr/config.h
+++ b/libwtr/config.h
@@ -1,12 +1,12 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include <glib.h>
+#include <stdlib.h>
 
 int		 config_load(void);
 void		 config_free(void);
 
-extern gsize nroots;
+extern size_t nroots;
 struct root {
 	int id;
 	char *name;

--- a/libwtr/freebsd.c
+++ b/libwtr/freebsd.c
@@ -14,7 +14,7 @@
 #include <glib.h>
 #include <glib-unix.h>
 
-#include "wtrd.h"
+#include "libwtr.h"
 
 #include "../libwtr/config.h"
 #include "../libwtr/database.h"

--- a/libwtr/libwtr.c
+++ b/libwtr/libwtr.c
@@ -1,0 +1,16 @@
+#include <string.h>
+
+#include "libwtr.h"
+
+void
+process_working_directory(const char *working_directory)
+{
+	for (size_t i = 0; i < nroots; i++) {
+		if (strnstr(working_directory, roots[i].root, strlen(roots[i].root)) == working_directory &&
+		    (working_directory[strlen(roots[i].root)] == '/' ||
+		     working_directory[strlen(roots[i].root)] == '\0')) {
+			roots[i].active = 1;
+			break;
+		}
+	}
+}

--- a/libwtr/libwtr.h
+++ b/libwtr/libwtr.h
@@ -1,0 +1,12 @@
+#ifndef LIBWTR_H
+#define LIBWTR_H
+
+#include "config.h"
+#include "database.h"
+#include "utils.h"
+
+
+void		 process_working_directory(const char *working_directory);
+void		 each_user_process_working_directory(void callback(const char *working_directory));
+
+#endif

--- a/libwtr/linux.c
+++ b/libwtr/linux.c
@@ -1,7 +1,7 @@
 #include <err.h>
 #include <glib.h>
 
-#include "wtrd.h"
+#include "libwtr.h"
 
 const char *proc = "/proc";
 

--- a/wtr/CMakeLists.txt
+++ b/wtr/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_executable(wtr wtr.c)
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET glib-2.0 sqlite3)
-target_link_libraries(wtr PkgConfig::deps libwtr)
+target_link_libraries(wtr libwtr)
 install(TARGETS wtr DESTINATION bin)

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -1,9 +1,8 @@
 #include <err.h>
 #include <stdio.h>
+#include <string.h>
 
-#include "../libwtr/config.h"
-#include "../libwtr/database.h"
-#include "../libwtr/utils.h"
+#include "../libwtr/libwtr.h"
 
 void
 print_duration(int duration)
@@ -107,7 +106,9 @@ main(int argc, char *argv[])
 		status(argc - 1, argv + 1, &from, &to);
 	}
 
-	for (gsize i = 0; i < nroots; i++) {
+	each_user_process_working_directory(process_working_directory);
+
+	for (size_t i = 0; i < nroots; i++) {
 		int duration;
 		if (from && to)
 			duration = database_project_get_duration3(roots[i].id, from, to);
@@ -117,7 +118,7 @@ main(int argc, char *argv[])
 		if (duration == 0)
 			continue;
 
-		printf("%-20s", roots[i].name);
+		printf("%-20s %s ", roots[i].name, roots[i].active ? "+" : " ");
 		print_duration(duration);
 		printf("\n");
 	}

--- a/wtrd/CMakeLists.txt
+++ b/wtrd/CMakeLists.txt
@@ -1,17 +1,13 @@
 add_executable(wtrd wtrd.c)
 find_package(PkgConfig REQUIRED)
+target_link_libraries(wtrd libwtr)
+install(TARGETS wtrd DESTINATION bin)
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-target_sources(wtrd PUBLIC freebsd.c)
-find_library(wtrd procstat)
 target_link_libraries(wtrd procstat)
 endif (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-target_sources(wtrd PUBLIC linux.c)
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET libbsd-overlay)
+pkg_check_modules(libbsd REQUIRED IMPORTED_TARGET libbsd-overlay)
+target_link_libraries(wtrd PkgConfig::libbsd)
 endif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET glib-2.0 sqlite3)
-target_link_libraries(wtrd PkgConfig::deps libwtr)
-install(TARGETS wtrd DESTINATION bin)

--- a/wtrd/wtrd.c
+++ b/wtrd/wtrd.c
@@ -1,32 +1,13 @@
 #include <err.h>
-#include <string.h>
 
 #include <glib.h>
 #include <glib-unix.h>
 
-#include "wtrd.h"
-
-#include "../libwtr/config.h"
-#include "../libwtr/database.h"
-#include "../libwtr/utils.h"
+#include "../libwtr/libwtr.h"
 
 int check_interval = 10;
 
 GMainLoop *main_loop;
-
-void
-process_working_directory(const char *working_directory)
-{
-	for (gsize i = 0; i < nroots; i++) {
-		if (strnstr(working_directory, roots[i].root, strlen(roots[i].root)) == working_directory &&
-		    (working_directory[strlen(roots[i].root)] == '/' ||
-		     working_directory[strlen(roots[i].root)] == '\0')) {
-			roots[i].active = 1;
-			break;
-		}
-	}
-
-}
 
 void
 record_working_time(void)

--- a/wtrd/wtrd.h
+++ b/wtrd/wtrd.h
@@ -1,6 +1,0 @@
-#ifndef WTRD_H
-#define WTRD_H
-
-void		 each_user_process_working_directory(void callback(const char *working_directory));
-
-#endif


### PR DESCRIPTION
When reporting time spent on project, mark currently active projects.
