### PR TITLE
Canonicalize projects root directories

### DIFF
--- a/libwtr/config.c
+++ b/libwtr/config.c
@@ -61,8 +61,10 @@ config_load(void)
 
 		roots[i].id = database_find_or_create_project_by_name(groups[i]);
 		roots[i].name = g_strdup(groups[i]);
-		roots[i].root = root;
+		roots[i].root = realpath(root, NULL);
 		roots[i].active = 0;
+
+		free(root);
 	}
 
 	g_strfreev(groups);


### PR DESCRIPTION
In order to compare correctly processes current working directories to
projects root directories, all path must be canonicalized.

Fixes #24 