### PR TITLE
Fix crash when a process have no working directory

### DIFF
--- a/libwtr/libwtr.c
+++ b/libwtr/libwtr.c
@@ -5,6 +5,10 @@
 void
 process_working_directory(const char *working_directory)
 {
+	if (!working_directory) {
+		return;
+	}
+
 	for (size_t i = 0; i < nroots; i++) {
 		if (strnstr(working_directory, roots[i].root, strlen(roots[i].root)) == working_directory &&
 		    (working_directory[strlen(roots[i].root)] == '/' ||


### PR DESCRIPTION
Under some circumstances, a process may not have a working directory,
for example if the working directory has been removed.

When this happen, we want to ignore the process.
