### PR TITLE
Fix beginning_of_month()

### DIFF
--- a/libwtr/utils.c
+++ b/libwtr/utils.c
@@ -41,7 +41,7 @@ beginning_of_month(time_t date)
 	tm->tm_sec = 0;
 	tm->tm_min = 0;
 	tm->tm_hour = 0;
-	tm->tm_mday = 0;
+	tm->tm_mday = 1;
 
 	return mktime(tm);
 }


### PR DESCRIPTION
According to ctime(3), the tm structure define tm_mday as:

> int tm_mday;    /* day of month (1 - 31) */

Setting it to 0 makes the generated date one day earlier that expected.
