### PR TITLE
Improve locked database handling

### DIFF
--- a/libwtr/database.c
+++ b/libwtr/database.c
@@ -35,6 +35,12 @@ database_open(void)
 		return -1;
 	}
 
+	if (sqlite3_busy_timeout(db, 1000) != SQLITE_OK) {
+		warn("Connet set database busy timeout");
+		sqlite3_close(db);
+		return -1;
+	}
+
 	free(database_file_path);
 	free(database_dir_path);
 


### PR DESCRIPTION
Add a timeout when the database is locked to avoid exiting immediately
when this situation occur.
