### PR TITLE
Add support for reporting interval

### DIFF
--- a/wtr/cmd_lexer.l
+++ b/wtr/cmd_lexer.l
@@ -27,6 +27,7 @@ until				{ return UNTIL; }
 this				{ return THIS; }
 last				{ return LAST; }
 ago				{ return AGO; }
+by				{ return BY; }
 days?				{ yylval.time_unit = (time_unit_t){1, 0, 0, 0}; return DAY; }
 weeks?				{ yylval.time_unit = (time_unit_t){0, 1, 0, 0}; return WEEK; }
 months?				{ yylval.time_unit = (time_unit_t){0, 0, 1, 0}; return MONTH; }

--- a/wtr/wtr.1
+++ b/wtr/wtr.1
@@ -91,6 +91,9 @@ Note: current week is not included
 .Ar n
 .Cm months
 Note: current month is not included.
+.El
+Alternatively, a start date and an end date can be passed:
+.Bl -bullet -compact
 .It
 .Cm since
 .Ar date
@@ -100,6 +103,15 @@ Note: current month is not included.
 Note:
 .Ar date
 is not included.
+.El
+In any case, a report can be split in smaller chunks with:
+.Bl -bullet -compact
+.It
+.Cm by day
+.It
+.Cm by week
+.It
+.Cm by month
 .El
 .Sh DURATIONS
 Multiple duration formats are supported:

--- a/wtr/wtr.h
+++ b/wtr/wtr.h
@@ -13,6 +13,7 @@ typedef struct {
 typedef struct {
     time_t since;
     time_t until;
+    time_t (*next)(time_t, int);
 } duration_t;
 
 int		 scan_date(const char *str, time_t *date);
@@ -22,6 +23,6 @@ void		 wtr_active(void);
 void		 wtr_add_duration_to_project(int duration, char *project);
 void		 wtr_edit(void);
 void		 wtr_list(void);
-void		 wtr_report(time_t from, time_t to);
+void		 wtr_report(duration_t duration);
 
 #endif


### PR DESCRIPTION
Allow to split a report into smaller chunks by specifying `by
<time_unit>` in reports, e.g. `wtr this month by week`.

Fixes #43
