### PR TITLE
Various fixes

### DIFF
--- a/wtr/cmd_parser.y
+++ b/wtr/cmd_parser.y
@@ -80,7 +80,7 @@ duration: INTEGER { $$.since = add_day(today(), $1); $$.until = add_day($$.since
 	| TODAY { $$.since = today(); $$.until = add_day($$.since, 1); }
 	| YESTERDAY { $$.since = add_day(today(), -1); $$.until = today(); }
 	| THIS time_unit { $$.since = time_unit_functions[$2].beginning_of(today()); $$.until = time_unit_functions[$2].add($$.since, 1); }
-	| INTEGER time_unit AGO { $$.since = time_unit_functions[$2].add(time_unit_functions[$2].beginning_of(today()), -$1); $$.until = time_unit_functions[$2].add($$.since, 1); }
+	| INTEGER time_unit AGO { $$.since = time_unit_functions[$2].add(today(), -$1); $$.until = time_unit_functions[$2].add($$.since, 1); }
 	| LAST time_unit { $$.since = time_unit_functions[$2].add(time_unit_functions[$2].beginning_of(today()), -1); $$.until = time_unit_functions[$2].add($$.since, 1); }
 	| LAST INTEGER time_unit { $$.since = time_unit_functions[$3].add(time_unit_functions[$3].beginning_of(today()), -$2); $$.until = time_unit_functions[$3].beginning_of(today()); }
 	;

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -207,7 +207,12 @@ wtr_report(duration_t duration)
 	time_t since = duration.since;
 	time_t until = duration.until;
 
+	time_t tomorrow = add_day(today(), 1);
+
 	each_user_process_working_directory(process_working_directory);
+
+	if ((since && !until) || until > tomorrow)
+		until = tomorrow;
 
 	int longest_name = 5;
 	for (size_t i = 0; i < nroots; i++) {

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -233,7 +233,7 @@ wtr_report(duration_t duration)
 		char ssince[BUFSIZ], suntil[BUFSIZ];
 		strftime(ssince, BUFSIZ, "%F", localtime(&since));
 		strftime(suntil, BUFSIZ, "%F", localtime(&stop));
-		printf("since %s until %s\n\n", ssince, suntil);
+		printf("wtr since %s until %s\n\n", ssince, suntil);
 
 		int total_duration = 0;
 		for (size_t i = 0; i < nroots; i++) {


### PR DESCRIPTION
These are minor fixes for better consistency:

- Fix `<n> <time_unit> ago` reporting
- Fix reports with only a start date
- Genrate wtr commands as report headers
