### PR TITLE
Only report active projects for current timespan

### DIFF
--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -210,6 +210,7 @@ wtr_report(duration_t duration)
 	time_t since = duration.since;
 	time_t until = duration.until;
 
+	time_t now = time(0);
 	time_t tomorrow = add_day(today(), 1);
 
 	each_user_process_working_directory(process_working_directory);
@@ -251,7 +252,7 @@ wtr_report(duration_t duration)
 
 			printf(format_string, roots[i].name);
 			print_duration(project_duration);
-			if (roots[i].active) {
+			if (roots[i].active && since <= now && now < stop) {
 				printf(" +");
 			}
 			printf("\n");


### PR DESCRIPTION
When reviewing data from the past, do not mark the currently active
projects as active.  The `+` marker is intended to show that a duration
is currently increasing, which does not make sense if we consider
timespans that do not include the current date and time.

Fixes #50
