### PR TITLE
Rework duration parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,6 @@ jobs:
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -C ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION "3.18")
 project("wtr")
+include(CTest)
 
 add_compile_options(-Wall -Wextra -Werror)
 add_definitions(-D_GNU_SOURCE)

--- a/libwtr/CMakeLists.txt
+++ b/libwtr/CMakeLists.txt
@@ -14,3 +14,5 @@ target_sources(libwtr PRIVATE linux.c)
 pkg_check_modules(libbsd REQUIRED IMPORTED_TARGET libbsd-overlay)
 target_link_libraries(libwtr PkgConfig::libbsd)
 endif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+
+add_subdirectory("tests")

--- a/libwtr/tests/CMakeLists.txt
+++ b/libwtr/tests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(test_scan_date test_scan_date.c)
+add_test(NAME scan_date COMMAND test_scan_date)
+target_link_libraries(test_scan_date libwtr)
+add_executable(test_scan_duration test_scan_duration.c)
+add_test(NAME scan_duration COMMAND test_scan_duration)
+target_link_libraries(test_scan_duration libwtr)

--- a/libwtr/tests/test_scan_date.c
+++ b/libwtr/tests/test_scan_date.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../utils.h"
+
+int res = 0;
+
+void
+test_scan_date(char *str, int expected_ret, time_t expected_date)
+{
+	printf("scan_date(\"%s\"):\n", str);
+
+	time_t date;
+	int ret = scan_date(str, &date);
+	printf("  should return %d: %d (%s)\n", expected_ret, ret, expected_ret == ret ? "OK" : "FAIL");
+
+	if (expected_ret != ret) {
+		res = 1;
+		return;
+	}
+
+	if (ret < 0)
+		return;
+
+	printf("  should scan %ld: %ld (%s)\n", expected_date, date, expected_date == date ? "OK" : "FAIL");
+	if (expected_date != date) {
+		res = 1;
+		return;
+	}
+}
+
+int
+main(void)
+{
+	setenv("TZ", "Pacific/Tahiti", 1);
+	test_scan_date("2023-05-20", 0, 1684576800);
+
+	setenv("TZ", "UTC", 1);
+	test_scan_date("2023-05-20", 0, 1684540800);
+
+	test_scan_date("1", -1, -1);
+	test_scan_date("random", -1, -1);
+
+	exit(res);
+}

--- a/libwtr/tests/test_scan_duration.c
+++ b/libwtr/tests/test_scan_duration.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../utils.h"
+
+int res = 0;
+
+void
+test_scan_duration(char *str, int expected_ret, int expected_duration)
+{
+	printf("scan_duration(\"%s\"):\n", str);
+
+	int duration;
+	int ret = scan_duration(str, &duration);
+	printf("  should return %d: %d (%s)\n", expected_ret, ret, expected_ret == ret ? "OK" : "FAIL");
+
+	if (expected_ret != ret) {
+		res = 1;
+		return;
+	}
+
+	if (ret < 0)
+		return;
+
+	printf("  should scan %d: %d (%s)\n", expected_duration, duration, expected_duration == duration ? "OK" : "FAIL");
+	if (expected_duration != duration) {
+		res = 1;
+		return;
+	}
+}
+
+int
+main(void)
+{
+	test_scan_duration("1", 0, 1);
+	test_scan_duration("3600", 0, 3600);
+	test_scan_duration("1:1", 0, 3660);
+	test_scan_duration("1:15", 0, 4500);
+	test_scan_duration("1:101", -1, 0);
+	test_scan_duration("2:20:15", 0, 8415);
+	test_scan_duration("1:1:1", 0, 3661);
+	test_scan_duration("1:01 extra", -1, -1);
+	test_scan_duration("random", -1, -1);
+
+	exit(res);
+}

--- a/libwtr/utils.c
+++ b/libwtr/utils.c
@@ -1,6 +1,45 @@
+#include <stdio.h>
 #include <time.h>
 
 #include "utils.h"
+
+int
+scan_date(const char *str, time_t *date)
+{
+	time_t now = time(0);
+	struct tm *tm = localtime(&now);
+
+	if (!strptime(str, "%Y-%m-%d", tm))
+		return -1;
+
+	tm->tm_sec = 0;
+	tm->tm_min = 0;
+	tm->tm_hour = 0;
+
+	*date = mktime(tm);
+	return 0;
+}
+
+int
+scan_duration(const char *str, int *duration)
+{
+	int hrs, min, sec;
+	char rest;
+
+	if (sscanf(str, "%d:%02d:%02d%c", &hrs, &min, &sec, &rest) == 3) {
+		*duration = hrs * 3600 + min * 60 + sec;
+		return 0;
+	}
+	if (sscanf(str, "%d:%02d%c", &hrs, &min, &rest) == 2) {
+		*duration = hrs * 3600 + min * 60;
+		return 0;
+	}
+	if (sscanf(str, "%d%c", &sec, &rest) == 1) {
+		*duration = sec;
+		return 0;
+	}
+	return -1;
+}
 
 time_t
 today(void)

--- a/libwtr/utils.h
+++ b/libwtr/utils.h
@@ -3,6 +3,8 @@
 
 #include <time.h>
 
+int		 scan_date(const char *str, time_t *date);
+int		 scan_duration(const char *str, int *duration);
 time_t		 today(void);
 time_t		 beginning_of_day(time_t date);
 time_t		 beginning_of_week(time_t date);

--- a/wtr/wtr.1
+++ b/wtr/wtr.1
@@ -129,9 +129,9 @@ Multiple duration formats are supported:
 .Cm :\c
 .Ar sec
 .It
-.Ar min\c
+.Ar hrs\c
 .Cm :\c
-.Ar sec
+.Ar min
 .It
 .Ar sec
 .It

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -12,44 +12,6 @@
 #include "cmd_lexer.h"
 #include "cmd_parser.h"
 
-int
-scan_date(const char *str, time_t *date)
-{
-	time_t now = time(0);
-	struct tm *tm = localtime(&now);
-
-	if (!strptime(str, "%Y-%m-%d", tm))
-		return -1;
-
-	tm->tm_sec = 0;
-	tm->tm_min = 0;
-	tm->tm_hour = 0;
-
-	*date = mktime(tm);
-	return 0;
-}
-
-int
-scan_duration(const char *str, int *duration)
-{
-	int hrs, min, sec;
-	char rest;
-
-	if (sscanf(str, "%d:%02d:%02d%c", &hrs, &min, &sec, &rest) == 3) {
-		*duration = hrs * 3600 + min * 60 + sec;
-		return 0;
-	}
-	if (sscanf(str, "%d:%02d%c", &min, &sec, &rest) == 2) {
-		*duration = min * 60 + sec;
-		return 0;
-	}
-	if (sscanf(str, "%d%c", &sec, &rest) == 1) {
-		*duration = sec;
-		return 0;
-	}
-	return -1;
-}
-
 static void
 print_duration(int duration)
 {
@@ -85,7 +47,7 @@ usage(int exit_code)
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Durations:\n");
 	fprintf(stderr, "  <sec>\n");
-	fprintf(stderr, "  <min>:<sec>\n");
+	fprintf(stderr, "  <hrs>:<min>\n");
 	fprintf(stderr, "  <hrs>:<min>:<sec>\n");
 	fprintf(stderr, "  <hrs>hrs\n");
 	fprintf(stderr, "  <min>min\n");


### PR DESCRIPTION
When a duration has the form xx:yy, parse it as hrs:min instead of
min:sec.  This match `journalctl` parsing of times.

While here, setup some basic unit tests and CI.

Fixes #56
