### PR TITLE
Add support for filtering by project

### DIFF
--- a/wtr/cmd_lexer.l
+++ b/wtr/cmd_lexer.l
@@ -29,6 +29,7 @@ last				{ return LAST; }
 ago				{ return AGO; }
 by				{ return BY; }
 rounding			{ return ROUNDING; }
+on				{ return ON; }
 days?				{ yylval.time_unit = (time_unit_t){1, 0, 0, 0}; return DAY; }
 weeks?				{ yylval.time_unit = (time_unit_t){0, 1, 0, 0}; return WEEK; }
 months?				{ yylval.time_unit = (time_unit_t){0, 0, 1, 0}; return MONTH; }

--- a/wtr/cmd_parser.y
+++ b/wtr/cmd_parser.y
@@ -22,6 +22,9 @@ struct {
 };
 
 report_options_t combine_report_parts(report_options_t a, report_options_t b);
+
+report_options_t empty_options;
+
 %}
 
 %define parse.trace
@@ -70,13 +73,13 @@ report: report report_part { $$ = combine_report_parts($1, $2); }
       | report_part { $$ = $1; }
       ;
 
-report_part: moment { $$ = $1; $$.next = NULL; $$.rounding = 0; }
-	   | SINCE DATE { $$.since = $2; $$.until = 0; $$.next = NULL; $$.rounding = 0; }
-	   | UNTIL DATE { $$.since = 0; $$.until = $2; $$.next = NULL; $$.rounding = 0; }
-	   | SINCE moment { $$.since = $2.since; $$.until = 0; $$.next = NULL; $$.rounding = 0; }
-	   | UNTIL moment { $$.since = 0; $$.until = $2.since; $$.next = NULL; $$.rounding = 0; }
-	   | BY time_unit { $$.since = 0; $$.until = 0; $$.next = time_unit_functions[$2].add; $$.rounding = 0; }
-	   | ROUNDING DURATION { $$.since = 0; $$.until = 0; $$.next = NULL; $$.rounding = $2; }
+report_part: moment { $$ = empty_options; $$.since = $1.since; $$.until = $1.until; }
+	   | SINCE DATE { $$ = empty_options; $$.since = $2; }
+	   | UNTIL DATE { $$ = empty_options; $$.until = $2; }
+	   | SINCE moment { $$ = empty_options; $$.since = $2.since; }
+	   | UNTIL moment { $$ = empty_options; $$.until = $2.since; }
+	   | BY time_unit { $$ = empty_options; $$.next = time_unit_functions[$2].add; }
+	   | ROUNDING DURATION { $$ = empty_options; $$.rounding = $2; }
 	   ;
 
 duration: INTEGER

--- a/wtr/wtr.1
+++ b/wtr/wtr.1
@@ -119,6 +119,12 @@ One can also round reported times to the next (upper) invoiced fraction:
 .Cm rounding
 .Ar duration
 .El
+Last, reports can be filtered to only show one or some porjects:
+.Bl -bullet -compact
+.It
+.Cm on
+.Ar project ...
+.El
 .Sh DURATIONS
 Multiple duration formats are supported:
 .Bl -bullet -compact

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -69,6 +69,7 @@ usage(int exit_code)
 	fprintf(stderr, "  since <date>\n");
 	fprintf(stderr, "  until <date>\n");
 	fprintf(stderr, "  rounding <duration>\n");
+	fprintf(stderr, "  on <project ...>\n");
 	exit(exit_code);
 }
 
@@ -203,6 +204,19 @@ wtr_report(report_options_t options)
 
 		int total_duration = 0;
 		for (size_t i = 0; i < nprojects; i++) {
+			if (options.projects) {
+				int found = 0;
+				project_list_t *item = options.projects;
+
+				for (item = options.projects; item; item = item->next) {
+					if (item->id == projects[i].id) {
+						found = 1;
+						break;
+					}
+				}
+				if (!found)
+					continue;
+			}
 			int project_duration;
 			int currently_active = projects[i].active && since <= now && now < stop;
 
@@ -241,5 +255,6 @@ wtr_report(report_options_t options)
 			printf("\n");
 	}
 
+	project_list_free(options.projects);
 	free(format_string);
 }

--- a/wtr/wtr.h
+++ b/wtr/wtr.h
@@ -10,12 +10,22 @@ typedef struct {
     int year;
 } time_unit_t;
 
+typedef struct project_list {
+    int id;
+    struct project_list *next;
+} project_list_t;
+
 typedef struct {
     time_t since;
     time_t until;
     time_t (*next)(time_t, int);
     int rounding;
+    project_list_t *projects;
 } report_options_t;
+
+project_list_t	*project_list_new(const char *name);
+project_list_t	*project_list_add(project_list_t *head, const char *name);
+void		 project_list_free(project_list_t *head);
 
 void		 wtr_active(void);
 void		 wtr_add_duration_to_project(int duration, const char *project);


### PR DESCRIPTION
Allow to specify a list of projects of interests. Information about
other projects are ignored:

```
wtr yesterday on foo bar
```

Will only show the time spent yesterday on projects `foo` and `bar`.

Fixes #61
