### PR TITLE
Add support for graph without explicit duration

### DIFF
--- a/wtr/cmd_parser.y
+++ b/wtr/cmd_parser.y
@@ -119,6 +119,7 @@ command: ACTIVE YYEOF { wtr_active(); }
        | ADD duration TO PROJECT YYEOF { wtr_add_duration_to_project($2, $4); }
        | REMOVE duration FROM PROJECT YYEOF { wtr_add_duration_to_project(- $2, $4); }
        | report YYEOF {  wtr_report($1); }
+       | GRAPH YYEOF { wtr_graph_auto(); }
        | GRAPH recursive_time_span YYEOF { wtr_graph($2); }
        ;
 

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -4,6 +4,7 @@
 #include <err.h>
 #include <stdio.h>
 #include <string.h>
+#include <termios.h>
 #include <unistd.h>
 
 #include "wtr.h"
@@ -367,4 +368,26 @@ wtr_graph(report_options_t options)
 	}
 
 	free(durations);
+}
+
+void
+wtr_graph_auto(void)
+{
+	struct winsize winsize;
+	tcgetwinsize(0, &winsize);
+	int weeks = (winsize.ws_col - 4) / 4 - 1;
+	/*                            |    |   `--- current week
+	 *                            |    `------- width of a day
+	 *                            `------------ length of header
+	 */
+
+	report_options_t auto_options = {
+		.since = beginning_of_week(add_week(today(), -weeks)),
+		.until = add_day(today(), 1),
+		.next = NULL,
+		.rounding = 0,
+		.projects = NULL,
+	};
+
+	wtr_graph(auto_options);
 }

--- a/wtr/wtr.h
+++ b/wtr/wtr.h
@@ -33,5 +33,6 @@ void		 wtr_edit(void);
 void		 wtr_list(void);
 void		 wtr_report(report_options_t options);
 void		 wtr_graph(report_options_t options);
+void		 wtr_graph_auto(void);
 
 #endif


### PR DESCRIPTION
If no duration is provided, display the maximum allowed duration given
the terminal width.
