### PR TITLE
Remove db global variable

### DIFF
--- a/libwtr/config.c
+++ b/libwtr/config.c
@@ -26,7 +26,7 @@ config_file_path(void)
 }
 
 int
-config_load(void)
+config_load(struct database *database)
 {
 	char *conf_file_path = config_file_path();
 
@@ -59,7 +59,7 @@ config_load(void)
 			return -1;
 		}
 
-		projects[i].id = database_project_find_or_create_by_name(groups[i]);
+		projects[i].id = database_project_find_or_create_by_name(database, groups[i]);
 		projects[i].name = g_strdup(groups[i]);
 		projects[i].root = realpath(root, NULL);
 		projects[i].active = 0;

--- a/libwtr/config.h
+++ b/libwtr/config.h
@@ -3,8 +3,10 @@
 
 #include <stdlib.h>
 
+#include "database.h"
+
 char		*config_file_path(void);
-int		 config_load(void);
+int		 config_load(struct database *database);
 void		 config_free(void);
 
 extern size_t nprojects;

--- a/libwtr/database.h
+++ b/libwtr/database.h
@@ -3,13 +3,15 @@
 
 #include <time.h>
 
-int		 database_open(void);
-void		 database_close(void);
+struct database;
 
-int		 database_project_find_by_name(const char *project);
-int		 database_project_find_or_create_by_name(const char *project);
-void		 database_project_add_duration(int project_id, time_t date, int duration);
-int		 database_get_duration(time_t since, time_t until, const char *and_project_in);
-int		 database_project_get_duration(int project_id, time_t since, time_t until);
+struct database	*database_open(void);
+void		 database_close(struct database *db);
+
+int		 database_project_find_by_name(struct database *db, const char *project);
+int		 database_project_find_or_create_by_name(struct database *db, const char *project);
+void		 database_project_add_duration(struct database *db, int project_id, time_t date, int duration);
+int		 database_get_duration(struct database *db, time_t since, time_t until, const char *and_project_in);
+int		 database_project_get_duration(struct database *db, int project_id, time_t since, time_t until);
 
 #endif

--- a/wtr/wtr.h
+++ b/wtr/wtr.h
@@ -3,6 +3,8 @@
 
 #include <time.h>
 
+#include "../libwtr/database.h"
+
 typedef struct {
     int day;
     int week;
@@ -23,16 +25,16 @@ typedef struct {
     project_list_t *projects;
 } report_options_t;
 
-project_list_t	*project_list_new(const char *name);
-project_list_t	*project_list_add(project_list_t *head, const char *name);
+project_list_t	*project_list_new(struct database *database, const char *name);
+project_list_t	*project_list_add(struct database *database, project_list_t *head, const char *name);
 void		 project_list_free(project_list_t *head);
 
 void		 wtr_active(void);
-void		 wtr_add_duration_to_project_on(int duration, const char *project, time_t date);
+void		 wtr_add_duration_to_project_on(struct database *database, int duration, const char *project, time_t date);
 void		 wtr_edit(void);
 void		 wtr_list(void);
-void		 wtr_report(report_options_t options);
-void		 wtr_graph(report_options_t options);
-void		 wtr_graph_auto(project_list_t *projects);
+void		 wtr_report(struct database *database, report_options_t options);
+void		 wtr_graph(struct database *database, report_options_t options);
+void		 wtr_graph_auto(struct database *database, project_list_t *projects);
 
 #endif


### PR DESCRIPTION
In order to merge databases, we will need to have access to multiple
databases simultaneously and a global variable is not elegant.
