### PR TITLE
Rework reports creation

### DIFF
--- a/libwtr/database.h
+++ b/libwtr/database.h
@@ -18,6 +18,6 @@ int		 database_project_find_by_name(struct database *db, const char *project);
 int		 database_project_find_or_create_by_name(struct database *db, const char *project);
 void		 database_project_add_duration(struct database *db, int project_id, time_t date, int duration);
 int		 database_get_duration(struct database *db, time_t since, time_t until, const char *sql_filter);
-int		 database_project_get_duration(struct database *db, int project_id, time_t since, time_t until, char *sql_filter);
+int		 database_get_duration_by_project(struct database *db, time_t since, time_t until, char *sql_filter, void (*callback)(const char *project, int duration, void *data), void *data);
 
 #endif


### PR DESCRIPTION
Instead of requesting the time spent on all configured projects one by
one, query the database to return metrics for all known projects
(including those not configured locally).  This allows to produce
identical results on different hosts when their database got merged.

Fixes #80
