### PR TITLE
Fix getting the longuest project name

### DIFF
--- a/libwtr/database.c
+++ b/libwtr/database.c
@@ -25,6 +25,17 @@ host_id(struct database *database)
 	return _host_id;
 }
 
+static int
+read_single_integer(void *result, int argc, char **argv, char **column_name)
+{
+	(void) column_name;
+
+	if (argc == 1 && argv[0]) {
+		sscanf(argv[0], "%d", (int *) result);
+	}
+	return 0;
+}
+
 void
 insert_current_host(struct database *database)
 {
@@ -110,6 +121,20 @@ database_open(char *filename)
 	return res;
 }
 
+int
+database_longuest_project_name(struct database *database)
+{
+	int res;
+
+	char *errmsg;
+	if (sqlite3_exec(database->db, "SELECT MAX(LENGTH(name)) FROM projects", read_single_integer, &res, &errmsg) != SQLITE_OK) {
+		errx(EXIT_FAILURE, "%s", errmsg);
+		/* NOTREACHED */
+	}
+
+	return res;
+}
+
 static int
 find_applied_migrations(void *not_used, int argc, char **argv, char **column_name)
 {
@@ -180,17 +205,6 @@ database_migrate(struct database *database)
 		}
 
 	}
-}
-
-static int
-read_single_integer(void *result, int argc, char **argv, char **column_name)
-{
-	(void) column_name;
-
-	if (argc == 1 && argv[0]) {
-		sscanf(argv[0], "%d", (int *) result);
-	}
-	return 0;
 }
 
 int

--- a/libwtr/database.h
+++ b/libwtr/database.h
@@ -9,6 +9,7 @@ char		*database_path(void);
 struct database	*database_open(char *filename);
 void		 database_close(struct database *db);
 
+int		 database_longuest_project_name(struct database *db);
 void		 database_merge(struct database *db, struct database *import);
 int		 database_host_find_by_name(struct database *db, const char *project);
 int		 database_host_find_or_create_by_name(struct database *db, const char *project);

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -259,12 +259,7 @@ wtr_report(struct database *database, report_options_t options)
 	if (!until)
 		until = tomorrow;
 
-	int longest_name = 5;
-	for (size_t i = 0; i < nprojects; i++) {
-		int name_length = strlen(projects[i].name);
-		if (name_length > longest_name)
-			longest_name = name_length;
-	}
+	int longest_name = database_longuest_project_name(database);
 	char *format_string;
 	if (asprintf(&format_string, "    %%-%ds ", longest_name) < 0)
 		err(EXIT_FAILURE, "asprintf");


### PR DESCRIPTION
Database may contain projects not part of the host configuration.  We
should use the database to determine what is the longuest project name.
