### PR TITLE
Always display active projects

### DIFF
--- a/libwtr/database.h
+++ b/libwtr/database.h
@@ -19,6 +19,6 @@ int		 database_project_find_by_name(struct database *db, const char *project);
 int		 database_project_find_or_create_by_name(struct database *db, const char *project);
 void		 database_project_add_duration(struct database *db, int project_id, time_t date, int duration);
 int		 database_get_duration(struct database *db, time_t since, time_t until, const char *sql_filter);
-int		 database_get_duration_by_project(struct database *db, time_t since, time_t until, char *sql_filter, void (*callback)(const char *project, int duration, void *data), void *data);
+int		 database_get_duration_by_project(struct database *db, time_t since, time_t until, char *project_sql_filter, char *host_sql_filter, void (*callback)(const char *project, int duration, void *data), void *data);
 
 #endif


### PR DESCRIPTION
An active project with no time recorded yet should always be reported.
Because a JOIN query with SUM does not produce a line for projects
without activity, switch to a composite query with sub-queries to gather
the actual sum.

While here improve error reporting.
