### PR TITLE
Always check all projects against process directory

### DIFF
--- a/libwtr/libwtr.c
+++ b/libwtr/libwtr.c
@@ -14,7 +14,6 @@ process_working_directory(const char *working_directory)
 		    (working_directory[strlen(projects[i].root)] == '/' ||
 		     working_directory[strlen(projects[i].root)] == '\0')) {
 			projects[i].active = 1;
-			break;
 		}
 	}
 }


### PR DESCRIPTION
If some projects are nested, we want to count time for all projects, not
only for the first matching one.
