### PR TITLE
Copy yytext between scanner and parser

### DIFF
--- a/wtr/cmd_lexer.l
+++ b/wtr/cmd_lexer.l
@@ -1,5 +1,6 @@
 %{
 
+#include <err.h>
 #include <time.h>
 
 #include "wtr.h"
@@ -52,7 +53,7 @@ years?				{ yylval.time_unit = (time_unit_t){0, 0, 0, 0, 1}; return YEAR; }
 
 [0-9]{4}-[0-9]{2}-[0-9]{2}	{ scan_date(yytext,&yylval.date); return DATE; }
 -?[0-9]+			{ yylval.integer = strtol(yytext, NULL, 10); return INTEGER; }
-.+				{ yylval.string = yytext; return IDENTIFIER; }
+.+				{ if (!(yylval.string = strdup(yytext))) { err(EXIT_FAILURE, "strdup"); }; return IDENTIFIER; }
 
 %%
 

--- a/wtr/cmd_parser.y
+++ b/wtr/cmd_parser.y
@@ -117,6 +117,8 @@ report_options_t empty_options;
 
 %parse-param {struct database *database}
 
+%destructor { free($$); } <string>
+
 %%
 
 command: ACTIVE YYEOF { wtr_active(); }


### PR DESCRIPTION
We need to make a copy of yytext in the scanner because the value may be
changed when scanning the rest of input and before the parser could
process the token.

Fix some calls like:
```
$ wtr add 5:00 to project on 2025-03-19
wtr: unknown project: on
```
