### PR TITLE
Add support for a debug flag

### DIFF
--- a/wtr/cmd_parser.y
+++ b/wtr/cmd_parser.y
@@ -72,12 +72,48 @@ id_list_free(id_list_t *head)
     }
 }
 
+void
+id_list_print(FILE *io, id_list_t *head)
+{
+    id_list_t *next;
+    while (head) {
+	next = head->next;
+	fprintf(io, "%d", head->id);
+	if (next)
+	    fprintf(io, ", ");
+	head = next;
+    }
+}
+
+void
+time_print(FILE *io, time_t time)
+{
+    struct tm *t = localtime(&time);
+    char buf[BUFSIZ];
+    strftime(buf, sizeof(buf), "%c", t);
+    fprintf(io, "%ld (%s)", time, buf);
+}
+
 report_options_t empty_options;
 
 %}
 
 %define parse.trace
 %define parse.error verbose
+
+%printer { fprintf(yyo, "%d", $$); } <integer>;
+%printer { time_print(yyo, $$); } <date>;
+%printer { fprintf(yyo, "%s", $$); } <string>;
+%printer {
+    fprintf(yyo, "since=");
+    time_print(yyo, $$.since);
+    fprintf(yyo, " until=");
+    time_print(yyo, $$.until);
+    fprintf(yyo, " rounding=%d projects=%p hosts=%p", $$.rounding, $$.projects, $$.hosts); } <report_options>;
+%printer {
+    fprintf(yyo, "<%p> ", $$);
+    id_list_print(yyo, $$);
+} <projects> <hosts>;
 
 %union {
     int integer;

--- a/wtr/cmd_parser.y
+++ b/wtr/cmd_parser.y
@@ -117,7 +117,6 @@ report_options_t empty_options;
 
 %union {
     int integer;
-    int project_id;
     time_t date;
     char *string;
     time_unit_t time_unit;

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -5,6 +5,7 @@
 #include <sys/wait.h>
 
 #include <err.h>
+#include <getopt.h>
 #include <glib.h>
 #include <locale.h>
 #include <stdio.h>
@@ -42,7 +43,10 @@ print_duration(int duration)
 static void
 usage(int exit_code)
 {
-	fprintf(stderr, "usage: wtr <command>\n");
+	fprintf(stderr, "usage: wtr [-d] <command>\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "Options:\n");
+	fprintf(stderr, "  -d, --debug                               Enable debug output\n");
 	fprintf(stderr, "\n");
 	fprintf(stderr, "Commands:\n");
 	fprintf(stderr, "  add <duration> to <project>               Add work time to a project\n");
@@ -162,9 +166,27 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	if (argc > 1) {
-		global_argc = argc - 1;
-		global_argv = argv + 1;
+	struct option longopts[] = {
+		{ "debug", no_argument, NULL, 'd' },
+		{ NULL, 0, NULL, 0 },
+	};
+
+	int ch;
+	while ((ch = getopt_long(argc, argv, "d", longopts, NULL)) != -1) {
+		switch (ch) {
+		case 'd':
+			yydebug = 1;
+			break;
+		default:
+			usage(EXIT_FAILURE);
+		}
+	}
+	argc -= optind;
+	argv += optind;
+
+	if (argc) {
+		global_argc = argc;
+		global_argv = argv;
 	} else {
 		global_argc = default_argc;
 		global_argv = default_argv;


### PR DESCRIPTION
Debugging parsers is tedious.  Add a flag to enable debug output at run-time.


