### PR TITLE
Show per-project activity

### DIFF
--- a/libwtr/libwtr.c
+++ b/libwtr/libwtr.c
@@ -13,7 +13,7 @@ process_working_directory(const char *working_directory)
 		if (strnstr(working_directory, projects[i].root, strlen(projects[i].root)) == working_directory &&
 		    (working_directory[strlen(projects[i].root)] == '/' ||
 		     working_directory[strlen(projects[i].root)] == '\0')) {
-			projects[i].active = 1;
+			projects[i].active += 1;
 		}
 	}
 }

--- a/wtr/CMakeLists.txt
+++ b/wtr/CMakeLists.txt
@@ -5,7 +5,7 @@ bison_target(cmd_parser ${CMAKE_CURRENT_SOURCE_DIR}/cmd_parser.y ${CMAKE_CURRENT
 add_flex_bison_dependency(cmd_lexer cmd_parser)
 add_executable(wtr wtr.c ${BISON_cmd_parser_OUTPUTS} ${FLEX_cmd_lexer_OUTPUTS})
 find_package(PkgConfig REQUIRED)
-target_link_libraries(wtr libwtr)
+target_link_libraries(wtr libwtr m)
 install(TARGETS wtr DESTINATION bin)
 install(FILES wtr.1 DESTINATION man/man1)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -8,6 +8,7 @@
 #include <getopt.h>
 #include <glib.h>
 #include <locale.h>
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <termios.h>
@@ -283,7 +284,7 @@ report_project_duration(const char *project, int duration, void *user_data)
 	if (data->current) {
 		for (size_t i = 0; i < nprojects; i++) {
 			if (projects[i].active && strcmp((const char *)project, projects[i].name) == 0) {
-				active = 1;
+				active += projects[i].active;
 			}
 		}
 	}
@@ -292,7 +293,10 @@ report_project_duration(const char *project, int duration, void *user_data)
 		wprintf(data->wformat_string, project);
 		print_duration(duration);
 		if (active) {
-			wprintf(L" +");
+			wprintf(L" ");
+			for (int n = floor(log2(active + 1)); n > 0; n--) {
+				wprintf(L"+");
+			}
 		}
 		wprintf(L"\n");
 	}


### PR DESCRIPTION
Active projects where marked with a single '+', giving no information
about the number of process running and accounting for them.

Track the number of processes active for each project, and show this
number as a bar to help distinguish projects with a low number of
processes from those with a large number of processes.
