### PR TITLE
Fix dead initializations

### DIFF
--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -269,9 +269,7 @@ wtr_report(struct database *database, report_options_t options)
 	GString *project_sql_filter = g_string_new(NULL);
 	if (options.projects) {
 		g_string_append(project_sql_filter, " WHERE projects.id IN (");
-		id_list_t *item = options.projects;
-
-		for (item = options.projects; item; item = item->next) {
+		for (id_list_t *item = options.projects; item; item = item->next) {
 			g_string_append_printf(project_sql_filter, "%d", item->id);
 			if (item->next)
 				g_string_append(project_sql_filter, ", ");
@@ -282,9 +280,7 @@ wtr_report(struct database *database, report_options_t options)
 	GString *host_sql_filter = g_string_new(NULL);
 	if (options.hosts) {
 		g_string_append(host_sql_filter, " AND host_id IN (");
-		id_list_t *item = options.hosts;
-
-		for (item = options.hosts; item; item = item->next) {
+		for (id_list_t *item = options.hosts; item; item = item->next) {
 			g_string_append_printf(host_sql_filter, "%d", item->id);
 			if (item->next)
 				g_string_append(host_sql_filter, ", ");
@@ -373,9 +369,7 @@ wtr_graph(struct database *database, report_options_t options)
 	GString *sql_filter = g_string_new(NULL);
 	if (options.projects) {
 		g_string_append(sql_filter, " AND project_id IN (");
-		id_list_t *item = options.projects;
-
-		for (item = options.projects; item; item = item->next) {
+		for (id_list_t *item = options.projects; item; item = item->next) {
 			g_string_append_printf(sql_filter, "%d", item->id);
 			if (item->next)
 				g_string_append(sql_filter, ", ");
@@ -385,9 +379,7 @@ wtr_graph(struct database *database, report_options_t options)
 
 	if (options.hosts) {
 		g_string_append(sql_filter, " AND host_id IN (");
-		id_list_t *item = options.hosts;
-
-		for (item = options.hosts; item; item = item->next) {
+		for (id_list_t *item = options.hosts; item; item = item->next) {
 			g_string_append_printf(sql_filter, "%d", item->id);
 			if (item->next)
 				g_string_append(sql_filter, ", ");


### PR DESCRIPTION
```
/home/romain/Projects/wtr/wtr/wtr.c:272:14: warning: Value stored to 'item' during its initialization is never read [deadcode.DeadStores]
                id_list_t *item = options.projects;
                           ^~~~   ~~~~~~~~~~~~~~~~
/home/romain/Projects/wtr/wtr/wtr.c:285:14: warning: Value stored to 'item' during its initialization is never read [deadcode.DeadStores]
                id_list_t *item = options.hosts;
                           ^~~~   ~~~~~~~~~~~~~
/home/romain/Projects/wtr/wtr/wtr.c:376:14: warning: Value stored to 'item' during its initialization is never read [deadcode.DeadStores]
                id_list_t *item = options.projects;
                           ^~~~   ~~~~~~~~~~~~~~~~
/home/romain/Projects/wtr/wtr/wtr.c:388:14: warning: Value stored to 'item' during its initialization is never read [deadcode.DeadStores]
                id_list_t *item = options.hosts;
                           ^~~~   ~~~~~~~~~~~~~
4 warnings generated.
```
