### PR TITLE
Prefer database to find projects

### DIFF
--- a/wtr/cmd_parser.y
+++ b/wtr/cmd_parser.y
@@ -44,7 +44,7 @@ add_host_by_name(struct database *database, GList *list, const char *name)
 }
 
 GList *
-add_project_by_name(GList *list, const char *name)
+add_project_by_name(struct database *database, GList *list, const char *name)
 {
     bool found = false;
 
@@ -56,12 +56,10 @@ add_project_by_name(GList *list, const char *name)
 	    }
 	}
     } else {
-	for (size_t i = 0; i < nprojects; i++) {
-	    if (strcmp(projects[i].name, name) == 0) {
-		list = g_list_append(list, GINT_TO_POINTER(projects[i].id));
+	int id = database_project_find_by_name(database, name);
+	if (id >= 0) {
+		list = g_list_append(list, GINT_TO_POINTER(id));
 		found = true;
-		break;
-	    }
 	}
     }
 
@@ -238,8 +236,8 @@ time_unit: DAY { $$ = 0; }
 	 | YEAR { $$ = 4; }
 	 ;
 
-projects: projects IDENTIFIER { $$ = add_project_by_name($1, $2); free($2); }
-	| IDENTIFIER { $$ = add_project_by_name(NULL, $1); free($1); }
+projects: projects IDENTIFIER { $$ = add_project_by_name(database, $1, $2); free($2); }
+	| IDENTIFIER { $$ = add_project_by_name(database, NULL, $1); free($1); }
 	;
 
 hosts: hosts IDENTIFIER { $$ = add_host_by_name(database, $1, $2); free($2); }

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -340,7 +340,7 @@ wtr_add_duration_to_project_on(struct database *database, int duration, const ch
 {
 	int project_id = database_project_find_by_name(database, project);
 	if (project_id < 0) {
-		errx(EXIT_FAILURE, "unknown project: %s", project);
+		errx(EXIT_FAILURE, "%s: no such project", project);
 	}
 	database_project_add_duration(database, project_id, date, duration);
 }

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -342,11 +342,7 @@ wtr_add_duration_to_project_on(struct database *database, int duration, const ch
 	if (project_id < 0) {
 		errx(EXIT_FAILURE, "unknown project: %s", project);
 	}
-	for (size_t i = 0; i < nprojects; i++) {
-		if (project_id == projects[i].id) {
-			database_project_add_duration(database, projects[i].id, date, duration);
-		}
-	}
+	database_project_add_duration(database, project_id, date, duration);
 }
 
 void


### PR DESCRIPTION
The config may not contain some projects that exist into the database,
so we should look in the later rather than the former when possible.
