### PR TITLE
Fix total duration in reports with skipped projects

### DIFF
--- a/libwtr/database.c
+++ b/libwtr/database.c
@@ -461,11 +461,9 @@ database_get_duration(struct database *database, time_t since, time_t until, con
 	return duration;
 }
 
-int
+void
 database_get_duration_by_project(struct database *database, time_t since, time_t until, char *project_sql_filter, char *host_sql_filter, void (*callback)(const char *project, int duration, void *data), void *data)
 {
-	int total_duration = 0;
-
 	char *sql = NULL;
 
 	if (asprintf(&sql, "SELECT name, (SELECT COALESCE(SUM(duration), 0) FROM activity WHERE projects.id = project_id AND date >= %ld AND date < %ld%s) FROM projects %s ORDER BY LOWER(projects.name)", since, until, host_sql_filter, project_sql_filter) < 0) {
@@ -487,7 +485,6 @@ database_get_duration_by_project(struct database *database, time_t since, time_t
 		} else {
 			errx(EXIT_FAILURE, "sqlite3_step: %s", sqlite3_errstr(res));
 		}
-		total_duration += sqlite3_column_int(stmt, 1);
 	}
 
 	if ((res = sqlite3_finalize(stmt)) != SQLITE_OK) {
@@ -495,8 +492,6 @@ database_get_duration_by_project(struct database *database, time_t since, time_t
 	}
 
 	free(sql);
-
-	return total_duration;
 }
 
 struct import {

--- a/libwtr/database.h
+++ b/libwtr/database.h
@@ -20,6 +20,6 @@ int		 database_project_find_by_name(struct database *database, const char *proje
 int		 database_project_find_or_create_by_name(struct database *database, const char *project);
 void		 database_project_add_duration(struct database *database, int project_id, time_t date, int duration);
 int		 database_get_duration(struct database *database, time_t since, time_t until, const char *sql_filter);
-int		 database_get_duration_by_project(struct database *database, time_t since, time_t until, char *project_sql_filter, char *host_sql_filter, void (*callback)(const char *project, int duration, void *data), void *data);
+void		 database_get_duration_by_project(struct database *database, time_t since, time_t until, char *project_sql_filter, char *host_sql_filter, void (*callback)(const char *project, int duration, void *data), void *data);
 
 #endif

--- a/wtr/wtr.c
+++ b/wtr/wtr.c
@@ -416,6 +416,7 @@ wtr_list_projects(struct database *database)
 struct report_project_duration_data {
 	wchar_t *wformat_string;
 	int current;
+	int total_duration;
 };
 
 static void
@@ -433,6 +434,8 @@ report_project_duration(const char *project, int duration, void *user_data)
 	}
 
 	if (duration >= minimum_reported_duration || active) {
+		data->total_duration += duration;
+
 		wprintf(data->wformat_string, project);
 		print_duration(duration);
 		if (active) {
@@ -465,9 +468,9 @@ report_period(struct database *database, report_options_t options, time_t since,
 	struct report_project_duration_data data = {
 		.wformat_string = wformat_string,
 		.current = current,
+		.total_duration = 0,
 	};
-	int total_duration = 0;
-	total_duration = database_get_duration_by_project(database, since, stop, project_sql_filter, host_sql_filter, report_project_duration, &data);
+	database_get_duration_by_project(database, since, stop, project_sql_filter, host_sql_filter, report_project_duration, &data);
 
 	wprintf(L"    ");
 	for (int i = 0; i < longest_name + 19; i++) {
@@ -475,7 +478,7 @@ report_period(struct database *database, report_options_t options, time_t since,
 	}
 	wprintf(L"\n");
 	wprintf(wformat_string, "Total");
-	print_duration(total_duration);
+	print_duration(data.total_duration);
 	wprintf(L"\n");
 
 	if (!options.next) {


### PR DESCRIPTION
When projects have a recorded duration shorter that the minimum recorded duration, they are skipped and do not appear in reports.

However, the total at the end of the report does include these ignore projects, leading to inconsistent output.

Track the total duration in the project reporting function rather than at the project listing one, to allow skipping completely projects with a short recorded duration.

Fixes #130